### PR TITLE
Initial attempt to enable travis

### DIFF
--- a/.install_verilator.sh
+++ b/.install_verilator.sh
@@ -1,0 +1,19 @@
+set -e
+# Install Verilator (http://www.veripool.org/projects/verilator/wiki/Installing)
+if [ ! -f $INSTALL_DIR/bin/verilator ]; then 
+  mkdir -p $INSTALL_DIR
+  git clone http://git.veripool.org/git/verilator
+  unset VERILATOR_ROOT
+  cd verilator
+  git pull
+  git checkout verilator_3_922
+  autoconf
+  ./configure --prefix=$INSTALL_DIR
+  make
+  make install
+  export VERILATOR_ROOT=$INSTALL_DIR
+  # Fix verilator for local install (http://www.lowrisc.org/docs/untether-v0.2/verilator/)
+  ln -s $VERILATOR_ROOT/share/verilator/include $VERILATOR_ROOT/include
+  ln -s $VERILATOR_ROOT/share/verilator/bin/verilator_includer $VERILATOR_ROOT/bin/verilator_includer
+fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: scala
+sudo: false
+
+cache:
+  directories:
+    $HOME/.ivy2
+    $HOME/.sbt
+    $INSTALL_DIR
+
+env:
+  global:
+    INSTALL_DIR=$TRAVIS_BUILD_DIR/install
+    VERILATOR_ROOT=$INSTALL_DIR
+    PATH=$PATH:$VERILATOR_ROOT/bin
+    SBT_ARGS="-Dsbt.log.noformat=true"
+
+install:
+  - bash .install_verilator.sh
+  - verilator --version
+
+script:
+  - sbt $SBT_ARGS test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # EE 290C Wellness Monitor: ExG
 
+[![Build Status](https://travis-ci.org/ucberkeley-ee290c/fa18-wellness-monitor.svg?branch=master)](https://travis-ci.org/ucberkeley-ee290c/fa18-wellness-monitor)
+
 ## Team Members
 Adelson Chua, Justin Doong, Ryan Kaveh, Cem Yalcin, and Rachel Zoll
 


### PR DESCRIPTION
Travis is failing because `sbt test` produces too much output! I think the reason this happens is because the `DspTester` has its own notion of verbosity. My [PR for GPS](https://github.com/ucberkeley-ee290c/fa18-gps/pull/15) has fixes for this- can one of you make similar changes to make tests less verbose here?