### PR TITLE
Initial work to build wellness standalone.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,19 +14,16 @@ scalacOptions ++= Seq(
 
 parallelExecution in Test := false
 
-/*
 libraryDependencies ++= Seq(
-  "edu.berkeley.cs" %% "rocket-dsptools" % "1.2-102318-SNAPSHOT"
+  "edu.berkeley.cs" %% "rocket-dsptools" % "1.2-031419-SNAPSHOT"
 )
-*/
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")
 )
 
-
 name := "ee290c"
 organization := "edu.berkeley.cs"
 version := "0.1-SNAPSHOT"
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.8"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.8

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,0 +1,29 @@
+package wellness
+
+import chisel3._
+import dsptools.numbers._
+import freechips.rocketchip.amba.axi4stream._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+import scala.collection.mutable.ArrayBuffer
+
+object StandaloneWellness extends App {
+  implicit val p: Parameters = Parameters.empty
+
+  chisel3.Driver.execute(args, () => LazyModule(new TLWellnessGenDataPathBlock(
+    genParams = FixedPointWellnessParams.wellnessGenParams1,
+    datapathParamsArr = FixedPointWellnessGenParams.datapathsArr,
+    heritageArray = ArrayBuffer(),
+    pcaParams = FixedPointWellnessParams.pcaParams,
+    logisticParams = FixedPointWellnessParams.logisticParams,
+    configurationMemoryParams = FixedPointWellnessParams.configurationMemoryParams
+  ) with dspblocks.TLStandaloneBlock {
+    val ioInNode2 = BundleBridgeSource(() => new AXI4StreamBundle(AXI4StreamBundleParameters(n = 8)))
+
+    streamNode := BundleBridgeToAXI4Stream(AXI4StreamMasterParameters()) :=
+      ioInNode2
+
+    val in2 = InModuleBody { ioInNode2.makeIO() }
+  }).module)
+}


### PR DESCRIPTION
Run sbt "runMain wellness.StandaloneWellness" to generate the wellness peripheral (without read or write queues). This is a bit hacky and should be cleaned up.

It also bumps the dep on rocket-dsptools.